### PR TITLE
Refactored structure for retreiving reflection methods. If config is …

### DIFF
--- a/config/api-postman.php
+++ b/config/api-postman.php
@@ -87,4 +87,12 @@ return [
      */
     'disk' => 'local',
 
+    /*
+     * Generate for available controller methods only
+     *
+     * Forces generation to only generate items for actual methods instead of all the
+     * standard scaffolded ones. Useful for API resources where form routes are not used.
+     */
+    'available_methods_only' => true,
+
 ];

--- a/config/api-postman.php
+++ b/config/api-postman.php
@@ -86,13 +86,4 @@ return [
      * Specify the configured disk for storing the postman collection file.
      */
     'disk' => 'local',
-
-    /*
-     * Generate for available controller methods only
-     *
-     * Forces generation to only generate items for actual methods instead of all the
-     * standard scaffolded ones. Useful for API resources where form routes are not used.
-     */
-    'available_methods_only' => true,
-
 ];

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -150,7 +150,7 @@ class ExportPostmanCommand extends Command
         $routeData = explode('@', $routeAction['uses']);
         $reflection = new ReflectionClass($routeData[0]);
 
-        if ($this->config['available_methods_only'] && ! $reflection->hasMethod($routeData[1])) {
+        if (! $reflection->hasMethod($routeData[1])) {
             return null;
         }
 

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -65,27 +65,25 @@ class ExportPostmanCommand extends Command
                     }
                 }
 
-                if (empty($middlewares) || ! $includedMiddleware) {
+                if (empty($middlewares) || !$includedMiddleware) {
                     continue;
                 }
 
                 $requestRules = [];
 
+                $routeAction = $route->getAction();
+
+                $reflectionMethod = $this->getReflectionMethod($routeAction);
+
+                if (!$reflectionMethod) {
+                    continue;
+                }
+
                 if ($this->config['enable_formdata']) {
-                    $routeAction = $route->getAction();
-
-                    if ($routeAction['uses'] instanceof Closure) {
-                        $reflectionMethod = new ReflectionFunction($routeAction['uses']);
-                    } else {
-                        $routeData = explode('@', $routeAction['uses']);
-                        $reflection = new ReflectionClass($routeData[0]);
-                        $reflectionMethod = $reflection->getMethod($routeData[1]);
-                    }
-
                     $rulesParameter = null;
 
                     foreach ($reflectionMethod->getParameters() as $parameter) {
-                        if (! $parameterType = $parameter->getType()) {
+                        if (!$parameterType = $parameter->getType()) {
                             continue;
                         }
 
@@ -117,7 +115,7 @@ class ExportPostmanCommand extends Command
                 if ($this->isStructured()) {
                     $routeNames = $route->action['as'] ?? null;
 
-                    if (! $routeNames) {
+                    if (!$routeNames) {
                         $routeUri = explode('/', $route->uri());
 
                         // remove "api" from the start
@@ -128,7 +126,7 @@ class ExportPostmanCommand extends Command
 
                     $routeNames = explode('.', $routeNames);
                     $routeNames = array_filter($routeNames, function ($value) {
-                        return ! is_null($value) && $value !== '';
+                        return !is_null($value) && $value !== '';
                     });
 
                     $this->buildTree($this->structure, $routeNames, $request);
@@ -141,6 +139,22 @@ class ExportPostmanCommand extends Command
         Storage::disk($this->config['disk'])->put($exportName = "postman/$this->filename", json_encode($this->structure));
 
         $this->info("Postman Collection Exported: $exportName");
+    }
+
+    protected function getReflectionMethod(array $routeAction): ?object
+    {
+        if ($routeAction['uses'] instanceof Closure) {
+            return new ReflectionFunction($routeAction['uses']);
+        }
+
+        $routeData = explode('@', $routeAction['uses']);
+        $reflection = new ReflectionClass($routeData[0]);
+
+        if ($this->config['available_methods_only'] && !$reflection->hasMethod($routeData[1])) {
+            return null;
+        }
+
+        return $reflection->getMethod($routeData[1]);
     }
 
     protected function buildTree(array &$routes, array $segments, array $request): void
@@ -167,7 +181,7 @@ class ExportPostmanCommand extends Command
 
             unset($item);
 
-            if (! $matched) {
+            if (!$matched) {
                 $item = [
                     'name' => $segment,
                     'item' => $segment === $destination ? [$request] : [],
@@ -189,8 +203,8 @@ class ExportPostmanCommand extends Command
                 'method' => strtoupper($method),
                 'header' => $routeHeaders,
                 'url' => [
-                    'raw' => '{{base_url}}/'.$route->uri(),
-                    'host' => '{{base_url}}/'.$route->uri(),
+                    'raw' => '{{base_url}}/' . $route->uri(),
+                    'host' => '{{base_url}}/' . $route->uri(),
                 ],
             ],
         ];

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -65,7 +65,7 @@ class ExportPostmanCommand extends Command
                     }
                 }
 
-                if (empty($middlewares) || !$includedMiddleware) {
+                if (empty($middlewares) || ! $includedMiddleware) {
                     continue;
                 }
 
@@ -75,7 +75,7 @@ class ExportPostmanCommand extends Command
 
                 $reflectionMethod = $this->getReflectionMethod($routeAction);
 
-                if (!$reflectionMethod) {
+                if (! $reflectionMethod) {
                     continue;
                 }
 
@@ -83,7 +83,7 @@ class ExportPostmanCommand extends Command
                     $rulesParameter = null;
 
                     foreach ($reflectionMethod->getParameters() as $parameter) {
-                        if (!$parameterType = $parameter->getType()) {
+                        if (! $parameterType = $parameter->getType()) {
                             continue;
                         }
 
@@ -115,7 +115,7 @@ class ExportPostmanCommand extends Command
                 if ($this->isStructured()) {
                     $routeNames = $route->action['as'] ?? null;
 
-                    if (!$routeNames) {
+                    if (! $routeNames) {
                         $routeUri = explode('/', $route->uri());
 
                         // remove "api" from the start
@@ -126,7 +126,7 @@ class ExportPostmanCommand extends Command
 
                     $routeNames = explode('.', $routeNames);
                     $routeNames = array_filter($routeNames, function ($value) {
-                        return !is_null($value) && $value !== '';
+                        return ! is_null($value) && $value ! == '';
                     });
 
                     $this->buildTree($this->structure, $routeNames, $request);
@@ -150,7 +150,7 @@ class ExportPostmanCommand extends Command
         $routeData = explode('@', $routeAction['uses']);
         $reflection = new ReflectionClass($routeData[0]);
 
-        if ($this->config['available_methods_only'] && !$reflection->hasMethod($routeData[1])) {
+        if ($this->config['available_methods_only'] && ! $reflection->hasMethod($routeData[1])) {
             return null;
         }
 
@@ -181,7 +181,7 @@ class ExportPostmanCommand extends Command
 
             unset($item);
 
-            if (!$matched) {
+            if (! $matched) {
                 $item = [
                     'name' => $segment,
                     'item' => $segment === $destination ? [$request] : [],
@@ -203,8 +203,8 @@ class ExportPostmanCommand extends Command
                 'method' => strtoupper($method),
                 'header' => $routeHeaders,
                 'url' => [
-                    'raw' => '{{base_url}}/' . $route->uri(),
-                    'host' => '{{base_url}}/' . $route->uri(),
+                    'raw' => '{{base_url}}/'.$route->uri(),
+                    'host' => '{{base_url}}/'.$route->uri(),
                 ],
             ],
         ];

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -126,7 +126,7 @@ class ExportPostmanCommand extends Command
 
                     $routeNames = explode('.', $routeNames);
                     $routeNames = array_filter($routeNames, function ($value) {
-                        return ! is_null($value) && $value ! == '';
+                        return ! is_null($value) && $value !== '';
                     });
 
                     $this->buildTree($this->structure, $routeNames, $request);


### PR DESCRIPTION
…set to only allow generation for available controller methods the new function will return null if scaffolded functions are not available.

This is useful when making collections for Route::resource where Laravel scaffolding assumes model/{model}/create and similar view based routes that isn't actually in place. It also prevents items being generated for routes that points to non-existing methods.

Also a few PSR2 compliance automated fixes