### PR TITLE
Added confirmed rule handler

### DIFF
--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -77,35 +77,35 @@ class ExportPostmanCommand extends Command
                 }
 
                 if ($this->config['enable_formdata']) {
-					$rulesParameter = collect($reflectionMethod->getParameters())
-						->filter(function ($value, $key) {
-							$value = $value->getType();
-						
-							return $value && is_subclass_of($value->getName(), FormRequest::class);
-						})
-						->first();
+                    $rulesParameter = collect($reflectionMethod->getParameters())
+                        ->filter(function ($value, $key) {
+                            $value = $value->getType();
+                        
+                            return $value && is_subclass_of($value->getName(), FormRequest::class);
+                        })
+                        ->first();
 
-					if (! $rulesParameter) {
-						continue;
-					}
+                    if (! $rulesParameter) {
+                        continue;
+                    }
 
-					$rulesParameter = $rulesParameter->getType()->getName();
-					$rulesParameter = new $rulesParameter;
+                    $rulesParameter = $rulesParameter->getType()->getName();
+                    $rulesParameter = new $rulesParameter;
 
-					$requestRules = [];
-					$rules = method_exists($rulesParameter, 'rules') ? $rulesParameter->rules() : [];
+                    $requestRules = [];
+                    $rules = method_exists($rulesParameter, 'rules') ? $rulesParameter->rules() : [];
 
-					foreach ($rules as $fieldName => $rule) {
-						$requestRules[] = $fieldName;
+                    foreach ($rules as $fieldName => $rule) {
+                        $requestRules[] = $fieldName;
 
-						if (is_string($rule)) {
-							$rule = preg_split('/\s*\|\s*/', $rule);
-						}
+                        if (is_string($rule)) {
+                            $rule = preg_split('/\s*\|\s*/', $rule);
+                        }
 
-						if (in_array('confirmed', $rule)) {
-							$requestRules[] = $fieldName . '_confirmation';
-						}
-					}
+                        if (in_array('confirmed', $rule)) {
+                            $requestRules[] = $fieldName . '_confirmation';
+                        }
+                    }
                 }
 
                 $routeHeaders = $this->config['headers'];

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -80,7 +80,7 @@ class ExportPostmanCommand extends Command
                     $rulesParameter = collect($reflectionMethod->getParameters())
                         ->filter(function ($value, $key) {
                             $value = $value->getType();
-                        
+
                             return $value && is_subclass_of($value->getName(), FormRequest::class);
                         })
                         ->first();
@@ -103,7 +103,7 @@ class ExportPostmanCommand extends Command
                         }
 
                         if (in_array('confirmed', $rule)) {
-                            $requestRules[] = $fieldName . '_confirmation';
+                            $requestRules[] = $fieldName.'_confirmation';
                         }
                     }
                 }


### PR DESCRIPTION
When form data is enabled and `confirmed` rule exists, append an extra field using name + `_confirmation` notation just like Laravel expects. It works with both string-like and array-like rule syntax.

Eg. (rules):
```php
'password' => ['required', 'string', 'min:8', 'confirmed']
```
Result (form data fields):
```
password
password_confirmation
```