### PR TITLE
Add config option to not create crud folders.

### DIFF
--- a/config/api-postman.php
+++ b/config/api-postman.php
@@ -31,9 +31,12 @@ return [
     |
     | If you want folders to be generated based on namespace.
     |
+    | Set "crud_folders" to "false" if you don't want the api, index, store, show etc. folders.
+    |
     */
 
     'structured' => false,
+    'crud_folders' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -168,6 +168,16 @@ class ExportPostmanCommand extends Command
                         return ! is_null($value) && $value !== '';
                     });
 
+                    if (!$this->createCrudFolders()) {
+                        if (in_array(end($routeNames), ['index', 'store', 'show', 'update', 'destroy'])) {
+                            unset($routeNames[array_key_last($routeNames)]);
+                        }
+
+                        if ($routeNames[0] == 'api') {
+                            unset($routeNames[0]);
+                        }
+                    }
+
                     $this->buildTree($this->structure, $routeNames, $request);
                 } else {
                     $this->structure['item'][] = $request;
@@ -385,6 +395,11 @@ class ExportPostmanCommand extends Command
     protected function isStructured()
     {
         return $this->config['structured'];
+    }
+
+    protected function createCrudFolders()
+    {
+        return $this->config['crud_folders'];
     }
 
     /**

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -168,7 +168,7 @@ class ExportPostmanCommand extends Command
                         return ! is_null($value) && $value !== '';
                     });
 
-                    if (!$this->createCrudFolders()) {
+                    if (! $this->createCrudFolders()) {
                         if (in_array(end($routeNames), ['index', 'store', 'show', 'update', 'destroy'])) {
                             unset($routeNames[array_key_last($routeNames)]);
                         }


### PR DESCRIPTION
This pull requests adds a `crud_folders` option to the `api-postman.php` config. This allows the user to select whether they want the crud folders (index, store, show, update and destroy) in there postman collection or not.