### PR TITLE
Feature/ Event Support

### DIFF
--- a/config/api-postman.php
+++ b/config/api-postman.php
@@ -73,6 +73,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Events
+    |--------------------------------------------------------------------------
+    |
+    | If you want to configure the prequest and test scripts for the collection,
+    | then please provide paths to the javascript script files.
+    | 
+    | 'prerequest_script': This script will execute before every request in the collection.
+    | 'test_script': This script will execute after every request in the collection.
+    |
+    */
+
+    'prerequest_script' => '',
+    'test_script' => '',
+
+    /*
+    |--------------------------------------------------------------------------
     | Enable Form Data
     |--------------------------------------------------------------------------
     |

--- a/config/api-postman.php
+++ b/config/api-postman.php
@@ -78,14 +78,11 @@ return [
     |
     | If you want to configure the prequest and test scripts for the collection,
     | then please provide paths to the javascript script files.
-    | 
-    | 'prerequest_script': This script will execute before every request in the collection.
-    | 'test_script': This script will execute after every request in the collection.
     |
     */
 
-    'prerequest_script' => '',
-    'test_script' => '',
+    'prerequest_script' => '', // This script will execute before every request in the collection.
+    'test_script' => '', // This script will execute after every request in the collection.
 
     /*
     |--------------------------------------------------------------------------

--- a/config/api-postman.php
+++ b/config/api-postman.php
@@ -77,7 +77,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | If you want to configure the prequest and test scripts for the collection,
-    | then please provide paths to the javascript script files.
+    | then please provide paths to the JavaScript files.
     |
     */
 

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -375,7 +375,30 @@ class ExportPostmanCommand extends Command
                 'schema' => 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
             ],
             'item' => [],
+            'event' => []
         ];
+
+        $prerequestPath = $this->config['prerequest_script'];
+        $testPath = $this->config['test_script'];
+
+        if ($prerequestPath || $testPath) {
+            $scripts = [
+                'prerequest' => $prerequestPath,
+                'test' => $testPath,
+            ];
+
+            foreach ($scripts as $type => $path) {
+                if (file_exists($path)) {
+                    $this->structure['event'][] = [
+                        'listen' => $type,
+                        'script' => [
+                            'type' => 'text/javascript',
+                            'exec' => file_get_contents($path),
+                        ],
+                    ];
+                }
+            }
+        }
 
         if ($this->token) {
             $this->structure['variable'][] = [

--- a/src/Commands/ExportPostmanCommand.php
+++ b/src/Commands/ExportPostmanCommand.php
@@ -375,7 +375,7 @@ class ExportPostmanCommand extends Command
                 'schema' => 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
             ],
             'item' => [],
-            'event' => []
+            'event' => [],
         ];
 
         $prerequestPath = $this->config['prerequest_script'];

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -203,6 +203,35 @@ class ExportPostmanTest extends TestCase
         $this->assertCount(1, $fields->where('key', 'field_9')->where('description', 'The field 9 field is required., The field 9 must be a string.'));
     }
 
+
+    public function test_event_export_works()
+    {
+        $eventScriptPath = "tests/Fixtures/ExampleEvent.js";
+
+        config([
+            'api-postman.prerequest_script' => $eventScriptPath,
+            'api-postman.test_script' => $eventScriptPath,
+        ]);
+
+        $this->artisan('export:postman')->assertExitCode(0);
+
+        $this->assertTrue(true);
+
+        $collection = collect(json_decode(Storage::get('postman/'.config('api-postman.filename')), true)['event']);
+
+        $events = $collection
+            ->whereIn('listen', ['prerequest', 'test'])
+            ->all();
+
+        $this->assertCount(2, $events);
+
+        $content = file_get_contents($eventScriptPath);
+
+        foreach ($events as $event) {
+            $this->assertEquals($event['script']['exec'], $content);
+        }
+    }
+
     public function providerFormDataEnabled(): array
     {
         return [

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -203,7 +203,6 @@ class ExportPostmanTest extends TestCase
         $this->assertCount(1, $fields->where('key', 'field_9')->where('description', 'The field 9 field is required., The field 9 must be a string.'));
     }
 
-
     public function test_event_export_works()
     {
         $eventScriptPath = 'tests/Fixtures/ExampleEvent.js';

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -206,7 +206,7 @@ class ExportPostmanTest extends TestCase
 
     public function test_event_export_works()
     {
-        $eventScriptPath = "tests/Fixtures/ExampleEvent.js";
+        $eventScriptPath = 'tests/Fixtures/ExampleEvent.js';
 
         config([
             'api-postman.prerequest_script' => $eventScriptPath,

--- a/tests/Fixtures/ExampleEvent.js
+++ b/tests/Fixtures/ExampleEvent.js
@@ -1,0 +1,1 @@
+console.log("example event")

--- a/tests/Fixtures/ExampleEvent.js
+++ b/tests/Fixtures/ExampleEvent.js
@@ -1,1 +1,1 @@
-console.log("example event")
+console.log("example event");


### PR DESCRIPTION
## Feature/ Event Support

This PR adds support for collection level prerequest and test scripts. 

* Adds `prequest_script` and `test_script` config options
* Allows a path to a script file to be defined for each option
* If the specified files exist then the content of these is added to the relevant event property in the structure
* Adds test for this feature