### PR TITLE
[2.x] Laravel 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        testbench: ['^6.12', '^7.19', '^8.0']
+        testbench: ['^8.0']
     name: Testbench ${{ matrix.testbench }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Dependencies
         run: php /usr/bin/composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
       - name: Install Testbench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        testbench: ['^6.12', '^7.19']
+        testbench: ['^6.12', '^7.19', '^8.0']
     name: Testbench ${{ matrix.testbench }}
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "orchestra/testbench": "^6.12|^7.0|^8.0",
+        "orchestra/testbench": "^8.0",
         "phpunit/phpunit": "^10.0"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         }
     },
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
-        "illuminate/config": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/routing": "^6.0|^7.0|^8.0|^9.0|^10.0"
+        "illuminate/config": "^10.0",
+        "illuminate/console": "^10.0",
+        "illuminate/contracts": "^10.0",
+        "illuminate/support": "^10.0",
+        "illuminate/routing": "^10.0"
     },
     "extra": {
         "laravel": {
@@ -46,7 +46,7 @@
     "prefer-stable": true,
     "require-dev": {
         "orchestra/testbench": "^6.12|^7.0|^8.0",
-        "phpunit/phpunit": "^9.5|^10.0"
+        "phpunit/phpunit": "^10.0"
     },
     "scripts": {
         "test": "@php vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,8 @@
     "require-dev": {
         "orchestra/testbench": "^6.12|^7.0|^8.0",
         "phpunit/phpunit": "^9.5|^10.0"
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,11 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "illuminate/config": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/routing": "^6.0|^7.0|^8.0|^9.0"
+        "illuminate/config": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/routing": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "extra": {
         "laravel": {
@@ -45,7 +45,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "orchestra/testbench": "^6.12",
-        "phpunit/phpunit": "^9.5"
+        "orchestra/testbench": "^6.12|^7.0|^8.0",
+        "phpunit/phpunit": "^9.5|^10.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,6 @@
         "phpunit/phpunit": "^10.0"
     },
     "scripts": {
-        "test": "@php vendor/bin/phpunit"
+        "test": "phpunit"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  bootstrap="vendor/autoload.php"
-  backupGlobals="false"
-  backupStaticAttributes="false"
-  colors="true"
-  verbose="true"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  processIsolation="false"
-  stopOnFailure="false"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="vendor/autoload.php"
+	colors="true"
+	executionOrder="random"
+	failOnWarning="true"
+	failOnRisky="true"
+	failOnEmptyTestSuite="true"
+	beStrictAboutChangesToGlobalState="true"
+	beStrictAboutOutputDuringTests="true"
 >
   <coverage>
     <include>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,11 +3,7 @@
 	xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
 	bootstrap="vendor/autoload.php"
 	colors="true"
-	executionOrder="random"
-	failOnWarning="true"
-	failOnRisky="true"
-	failOnEmptyTestSuite="true"
-	beStrictAboutChangesToGlobalState="true"
+  verbose="true"
 >
   <coverage>
     <include>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,12 @@
 	xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
 	bootstrap="vendor/autoload.php"
 	colors="true"
-  verbose="true"
+	executionOrder="random"
+	failOnWarning="true"
+	failOnRisky="true"
+	failOnEmptyTestSuite="true"
+	beStrictAboutChangesToGlobalState="true"
+	beStrictAboutOutputDuringTests="true"
 >
   <coverage>
     <include>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
 	failOnRisky="true"
 	failOnEmptyTestSuite="true"
 	beStrictAboutChangesToGlobalState="true"
-	beStrictAboutOutputDuringTests="true"
 >
   <coverage>
     <include>

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -187,11 +187,11 @@ class ExportPostmanTest extends TestCase
 
         $fields = collect($targetRequest['request']['body']['urlencoded']);
         $this->assertCount(1, $fields->where('key', 'field_1')->where('description', 'The field 1 field is required.'));
-        $this->assertCount(1, $fields->where('key', 'field_2')->where('description', 'The field 2 field is required., The field 2 must be an integer.'));
-        $this->assertCount(1, $fields->where('key', 'field_3')->where('description', '(Optional), The field 3 must be an integer.'));
-        $this->assertCount(1, $fields->where('key', 'field_4')->where('description', '(Nullable), The field 4 must be an integer.'));
+        $this->assertCount(1, $fields->where('key', 'field_2')->where('description', 'The field 2 field is required., The field 2 field must be an integer.'));
+        $this->assertCount(1, $fields->where('key', 'field_3')->where('description', '(Optional), The field 3 field must be an integer.'));
+        $this->assertCount(1, $fields->where('key', 'field_4')->where('description', '(Nullable), The field 4 field must be an integer.'));
         // the below fails locally, but passes on GitHub actions?
-        $this->assertCount(1, $fields->where('key', 'field_5')->where('description', 'The field 5 field is required., The field 5 must be an integer., The field 5 must not be greater than 30., The field 5 must be at least 1.'));
+        $this->assertCount(1, $fields->where('key', 'field_5')->where('description', 'The field 5 field is required., The field 5 field must be an integer., The field 5 field must not be greater than 30., The field 5 field must be at least 1.'));
 
         /** This looks bad, but this is the default message in lang/en/validation.php, you can update to:.
          *
@@ -200,7 +200,7 @@ class ExportPostmanTest extends TestCase
         $this->assertCount(1, $fields->where('key', 'field_6')->where('description', 'The selected field 6 is invalid.'));
         $this->assertCount(1, $fields->where('key', 'field_7')->where('description', 'The field 7 field is required.'));
         $this->assertCount(1, $fields->where('key', 'field_8')->where('description', 'validation.'));
-        $this->assertCount(1, $fields->where('key', 'field_9')->where('description', 'The field 9 field is required., The field 9 must be a string.'));
+        $this->assertCount(1, $fields->where('key', 'field_9')->where('description', 'The field 9 field is required., The field 9 field must be a string.'));
     }
 
     public function test_event_export_works()

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -231,7 +231,7 @@ class ExportPostmanTest extends TestCase
         }
     }
 
-    public function providerFormDataEnabled(): array
+    public static function providerFormDataEnabled(): array
     {
         return [
             [


### PR DESCRIPTION
I needed to drop support for anything bellow Laravel 10 because validation messages changed and tests wont pass for lower versions so this should probably be a 2.0 release.

UPDATE: for some reason "Cached test" fails... something with seriazable closure