### PR TITLE
fix: remove null items while authentication is not specified

### DIFF
--- a/src/Processors/RouteProcessor.php
+++ b/src/Processors/RouteProcessor.php
@@ -142,6 +142,8 @@ class RouteProcessor
             'method' => strtoupper($method),
             'header' => collect($this->config['headers'])
                 ->push($this->authentication?->toArray())
+                ->filter()
+                ->values()
                 ->all(),
             'url' => [
                 'raw' => '{{base_url}}/'.$uri,


### PR DESCRIPTION
Exported collection was like this:
```
...
"header": [
	{
		"key": "Accept",
		"value": "application\/json"
	},
	{
		"key": "Content-Type",
		"value": "application\/json"
	},
	null
],
...
```

Postman error:
```
Error while importing Postman Collection v2.1: Cannot read properties of null (reading 'disabled')
```