### PR TITLE
Fix collection merging bug

### DIFF
--- a/src/Processors/RouteProcessor.php
+++ b/src/Processors/RouteProcessor.php
@@ -169,11 +169,11 @@ class RouteProcessor
                 ]);
 
                 if ($method === 'GET') {
-                    return $collection->mergeRecursive(collect([
+                    return $collection->mergeRecursive([
                         'url' => [
                             'query' => $rules->map(fn ($value) => array_merge($value, ['disabled' => false])),
                         ]
-                    ]));
+                    ]);
                 }
 
                 return $collection->put('body', [

--- a/src/Processors/RouteProcessor.php
+++ b/src/Processors/RouteProcessor.php
@@ -169,9 +169,11 @@ class RouteProcessor
                 ]);
 
                 if ($method === 'GET') {
-                    return $collection->put('url', [
-                        'query' => $rules->map(fn ($value) => array_merge($value, ['disabled' => false])),
-                    ]);
+                    return $collection->mergeRecursive(collect([
+                        'url' => [
+                            'query' => $rules->map(fn ($value) => array_merge($value, ['disabled' => false])),
+                        ]
+                    ]));
                 }
 
                 return $collection->put('body', [

--- a/src/Processors/RouteProcessor.php
+++ b/src/Processors/RouteProcessor.php
@@ -172,7 +172,7 @@ class RouteProcessor
                     return $collection->mergeRecursive([
                         'url' => [
                             'query' => $rules->map(fn ($value) => array_merge($value, ['disabled' => false])),
-                        ]
+                        ],
                     ]);
                 }
 

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -184,13 +184,13 @@ class ExportPostmanTest extends TestCase
         $this->assertEqualsCanonicalizing([
             'raw' => '{{base_url}}/example/getWithFormRequest',
             'host' => [
-                '{{base_url}}'
+                '{{base_url}}',
             ],
             'path' => [
                 'example',
-                'getWithFormRequest'
+                'getWithFormRequest',
             ],
-            'variable' => []
+            'variable' => [],
         ], array_slice($targetRequest['request']['url'], 0, 4));
 
         $fields = collect($targetRequest['request']['url']['query']);

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -181,6 +181,17 @@ class ExportPostmanTest extends TestCase
             ->where('name', 'example/getWithFormRequest')
             ->first();
 
+        $this->assertEqualsCanonicalizing([
+            'raw' => '{{base_url}}/getWithFormRequest',
+            'host' => [
+                '{{base_url}}'
+            ],
+            'path' => [
+                'getWithFormRequest'
+            ],
+            'variable' => []
+        ], array_slice($targetRequest['request']['url'], 0, 4));
+
         $fields = collect($targetRequest['request']['url']['query']);
         $this->assertCount(1, $fields->where('key', 'field_1')->where('description', 'required'));
         $this->assertCount(1, $fields->where('key', 'field_2')->where('description', 'required, integer'));

--- a/tests/Feature/ExportPostmanTest.php
+++ b/tests/Feature/ExportPostmanTest.php
@@ -182,11 +182,12 @@ class ExportPostmanTest extends TestCase
             ->first();
 
         $this->assertEqualsCanonicalizing([
-            'raw' => '{{base_url}}/getWithFormRequest',
+            'raw' => '{{base_url}}/example/getWithFormRequest',
             'host' => [
                 '{{base_url}}'
             ],
             'path' => [
+                'example',
                 'getWithFormRequest'
             ],
             'variable' => []


### PR DESCRIPTION
<img width="1342" alt="Scherm­afbeelding 2024-04-01 om 20 05 38" src="https://github.com/andreaselia/laravel-api-to-postman/assets/43108191/702a5a50-c014-4cb2-a7e7-11131631da5a">

The ->put('url') overwrites the url part of the collection instead of adding to it upon GET requests.

<img width="880" alt="Scherm­afbeelding 2024-04-01 om 20 06 30" src="https://github.com/andreaselia/laravel-api-to-postman/assets/43108191/3ddd6382-ed59-4636-91f5-8db0b34f7c43">
Snippet run in tinkerwell now correctly merges the data into the collection

Would you also like me to extend the test for this? As the test only looks for the 'query' part inside the 'url'?