### PR TITLE
Removing tag from publish command as it doesn't work and isn't necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ composer require andreaselia/laravel-api-to-postman
 Publish the config file:
 
 ```bash
-php artisan vendor:publish --provider="AndreasElia\PostmanGenerator\PostmanGeneratorServiceProvider" --tag="postman-config"
+php artisan vendor:publish --provider="AndreasElia\PostmanGenerator\PostmanGeneratorServiceProvider"
 ```
 
 ## Configuration


### PR DESCRIPTION
Before:
<img width="433" alt="image" src="https://github.com/user-attachments/assets/d60baa3e-aae1-442f-a77a-8273b15dd2fd" />

After:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/e9394591-72c3-4bd4-8189-8477d11fc8a7" />
